### PR TITLE
Add Bucket name to dev portal config

### DIFF
--- a/config/dev-portal.json
+++ b/config/dev-portal.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://cdn.zuplo.com/schemas/dev-portal.json",
-  "enableAuthentication": true
+  "enableAuthentication": true,
+  "apiKeys": {
+    "bucketName": "z$env(ZUPLO_PROJECT_ID)-$env(ZUPLO_ENVIRONMENT_TYPE)"
+  }
 }


### PR DESCRIPTION
Adding in the bucket name property here to match the new project template [here](https://github.com/zuplo/core/blob/f8b0a09f055705cecf7e937b4973d115dbd47a37/packages/core/templates/dev-portal.template.json#L5-L6)